### PR TITLE
Refactor chat interface and thinking mode toggle for improved UI

### DIFF
--- a/components/chat-interface.tsx
+++ b/components/chat-interface.tsx
@@ -538,49 +538,54 @@ This appears to be a request that I should handle with care and attention to det
                         variant={selectedTool === "kb-search" ? "default" : "outline"}
                         size="sm"
                         className={cn(
-                          "rounded-full h-8 px-3 flex items-center gap-1.5",
+                          "rounded-full h-8 px-2 flex items-center gap-1.5",
+                          open ? "lg:px-3" : "md:px-3",
                           selectedTool === "kb-search" ? "bg-primary text-primary-foreground" : "",
                         )}
                         onClick={() => handleToolSelect("kb-search")}
                       >
                         <Database className="h-4 w-4" />
-                        <span>KB Search</span>
+                        <span className={cn("hidden", open ? "lg:inline" : "md:inline")}>KB Search</span>
                       </Button>
                       <Button
                         variant={selectedTool === "web-search" ? "default" : "outline"}
                         size="sm"
                         className={cn(
-                          "rounded-full h-8 px-3 flex items-center gap-1.5",
+                          "rounded-full h-8 px-2 flex items-center gap-1.5",
+                          open ? "lg:px-3" : "md:px-3",
                           selectedTool === "web-search" ? "bg-primary text-primary-foreground" : "",
                         )}
                         onClick={() => handleToolSelect("web-search")}
                       >
                         <Search className="h-4 w-4" />
-                        <span>Web Search</span>
+                        <span className={cn("hidden", open ? "lg:inline" : "md:inline")}>Web Search</span>
                       </Button>
                       <Button
                         variant={selectedTool === "create-image" ? "default" : "outline"}
                         size="sm"
                         className={cn(
-                          "rounded-full h-8 px-3 flex items-center gap-1.5",
+                          "rounded-full h-8 px-2 flex items-center gap-1.5",
+                          open ? "lg:px-3" : "md:px-3",
                           selectedTool === "create-image" ? "bg-primary text-primary-foreground" : "",
                         )}
                         onClick={() => handleToolSelect("create-image")}
                       >
                         <ImageIcon className="h-4 w-4" />
-                        <span>Create Image</span>
+                        <span className={cn("hidden", open ? "lg:inline" : "md:inline")}>Create Image</span>
                       </Button>
                     </>
                   )}
+                  {/* Thinking Mode Toggle - positioned with other action buttons */}
+                  {thinkingAvailable && (
+                    <ThinkingModeToggle
+                      enabled={thinkingEnabled}
+                      available={thinkingAvailable}
+                      onToggle={setThinkingEnabled}
+                      className={open ? "lg:px-3" : "md:px-3"}
+                      textClassName={cn("hidden", open ? "lg:inline" : "md:inline")}
+                    />
+                  )}
                 </div>
-                {/* Thinking Mode Toggle - positioned at the farthest right */}
-                {thinkingAvailable && (
-                  <ThinkingModeToggle
-                    enabled={thinkingEnabled}
-                    available={thinkingAvailable}
-                    onToggle={setThinkingEnabled}
-                  />
-                )}
               </div>
             </div>
           </div>

--- a/components/thinking-mode-toggle.tsx
+++ b/components/thinking-mode-toggle.tsx
@@ -1,4 +1,4 @@
-import { Brain } from "lucide-react";
+import { Lightbulb, LightbulbOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -6,36 +6,46 @@ interface ThinkingModeToggleProps {
     enabled: boolean;
     available: boolean;
     onToggle: (enabled: boolean) => void;
+    className?: string;
+    textClassName?: string;
 }
 
 export function ThinkingModeToggle({
     enabled,
     available,
     onToggle,
+    className,
+    textClassName,
 }: ThinkingModeToggleProps) {
     if (!available) return null;
 
+    const IconComponent = enabled ? Lightbulb : LightbulbOff;
+
     return (
         <Button
-            variant="ghost"
-            size="icon"
+            variant="outline"
+            size="sm"
             onClick={() => onToggle(!enabled)}
             className={cn(
-                "h-8 w-8 rounded-full transition-colors",
-                enabled
-                    ? "bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800"
-                    : "hover:bg-secondary"
+                "rounded-full h-8 px-2 flex items-center gap-1.5 transition-all duration-200 hover:bg-accent",
+                className
             )}
             title={enabled ? "Disable thinking mode" : "Enable thinking mode"}
         >
-            <Brain
+            <IconComponent
                 className={cn(
-                    "h-4 w-4",
+                    "h-4 w-4 transition-all duration-200",
                     enabled
-                        ? "text-blue-600 dark:text-blue-400"
+                        ? "text-yellow-400 drop-shadow-sm"
                         : "text-muted-foreground"
                 )}
             />
+            <span className={cn(
+                "text-sm font-medium text-foreground transition-colors duration-200",
+                textClassName
+            )}>
+                Thinking
+            </span>
         </Button>
     );
 } 


### PR DESCRIPTION
This pull request introduces enhancements to the user interface for tool selection and the thinking mode toggle. The most significant changes include improving responsiveness and accessibility by adapting button styles based on screen size and user interaction, as well as updating the thinking mode toggle with a new design and functionality.

### UI Improvements for Tool Selection Buttons:
* Updated the padding and visibility of text labels in tool selection buttons (`kb-search`, `web-search`, `create-image`) to dynamically adjust based on screen size (`lg`, `md`) and the `open` state. This improves responsiveness and ensures better usability on different devices. (`components/chat-interface.tsx`, [components/chat-interface.tsxL541-R593](diffhunk://#diff-5a89c83e73ce4e2d22ecf701b63f19efac112ac8edd795da1b87cf478a32e74aL541-R593))

### Enhancements to Thinking Mode Toggle:
* Replaced the `Brain` icon with `Lightbulb` and `LightbulbOff` icons to better represent the enabled and disabled states of thinking mode. (`components/thinking-mode-toggle.tsx`, [components/thinking-mode-toggle.tsxL1-R48](diffhunk://#diff-28e8af03497cea1c10656d1efb8d06dcb62f51f5e5f4fb32f4499dbebac07453L1-R48))
* Added support for `className` and `textClassName` props to allow customization of button and text styles. This provides more flexibility for styling and integration with other components. (`components/thinking-mode-toggle.tsx`, [components/thinking-mode-toggle.tsxL1-R48](diffhunk://#diff-28e8af03497cea1c10656d1efb8d06dcb62f51f5e5f4fb32f4499dbebac07453L1-R48))
* Changed the button design from `ghost` to `outline`, updated the size to `sm`, and improved hover and transition effects for a more polished user experience. (`components/thinking-mode-toggle.tsx`, [components/thinking-mode-toggle.tsxL1-R48](diffhunk://#diff-28e8af03497cea1c10656d1efb8d06dcb62f51f5e5f4fb32f4499dbebac07453L1-R48))